### PR TITLE
Made it so only pickaxes can vein mine

### DIFF
--- a/src/main/java/com/ael/viner/util/MiningUtils.java
+++ b/src/main/java/com/ael/viner/util/MiningUtils.java
@@ -9,6 +9,7 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.InteractionHand;
@@ -16,6 +17,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.Level;
@@ -25,6 +27,7 @@ import net.minecraft.world.level.block.ShulkerBoxBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
@@ -45,6 +48,8 @@ public class MiningUtils {
      */
     public static void mineBlocks(ServerPlayer player, List<BlockPos> blocksToMine) {
         if (player == null)
+            return;
+        if (!player.isHolding(Ingredient.of(ItemTags.PICKAXES)))
             return;
 
         Level level = player.level();


### PR DESCRIPTION
noticed this due to pickarang being able to vein mine things when holding the keybind