### PR TITLE
Fix Slider Normalization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Viner
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT License
 # The mod version. See https://semver.org/
-mod_version=2.2.1
+mod_version=2.2.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/ael/viner/gui/ConfigScreen.java
+++ b/src/main/java/com/ael/viner/gui/ConfigScreen.java
@@ -103,7 +103,7 @@ public class ConfigScreen extends Screen {
 
         yStart += stepSize;
 
-        vineableLimitField = GuiUtils.createConfigSlider(leftColumnX, yStart, boxWidth, 20, 500, "Vineable Limit", Config.VINEABLE_LIMIT, newValue -> {
+        vineableLimitField = GuiUtils.createConfigSlider(leftColumnX, yStart, boxWidth, 20, 0,500, "Vineable Limit", Config.VINEABLE_LIMIT, newValue -> {
             Config.VINEABLE_LIMIT.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "vineableLimit");
         });
@@ -111,7 +111,7 @@ public class ConfigScreen extends Screen {
 
         yStart += stepSize;
 
-        exhaustionPerBlockField = GuiUtils.createConfigSlider(leftColumnX, yStart, boxWidth, 20, 20, "Hunger Per Block", Config.EXHAUSTION_PER_BLOCK, newValue -> {
+        exhaustionPerBlockField = GuiUtils.createConfigSlider(leftColumnX, yStart, boxWidth, 20,20, "Hunger Per Block", Config.EXHAUSTION_PER_BLOCK, newValue -> {
             Config.EXHAUSTION_PER_BLOCK.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.DOUBLE, newValue, "exhaustionPerBlock");
         });
@@ -129,7 +129,7 @@ public class ConfigScreen extends Screen {
         yStart += stepSize;
 
         // Height Above Slider
-        heightAboveField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 100, "Height Above", Config.HEIGHT_ABOVE, newValue -> {
+        heightAboveField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 0,100, "Height Above", Config.HEIGHT_ABOVE, newValue -> {
             Config.HEIGHT_ABOVE.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "heightAbove");
         });
@@ -138,7 +138,7 @@ public class ConfigScreen extends Screen {
         yStart += stepSize;
 
         // Height Below Slider
-        heightBelowField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 100, "Height Below", Config.HEIGHT_BELOW, newValue -> {
+        heightBelowField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 0,100, "Height Below", Config.HEIGHT_BELOW, newValue -> {
             Config.HEIGHT_BELOW.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "heightBelow");
         });
@@ -147,7 +147,7 @@ public class ConfigScreen extends Screen {
         yStart += stepSize;
 
         // Width Left Slider
-        widthLeftField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 100, "Width Left", Config.WIDTH_LEFT, newValue -> {
+        widthLeftField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 0,100, "Width Left", Config.WIDTH_LEFT, newValue -> {
             Config.WIDTH_LEFT.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "widthLeft");
         });
@@ -156,7 +156,7 @@ public class ConfigScreen extends Screen {
         yStart += stepSize;
 
         // Width Right Slider
-        widthRightField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 100, "Width Right", Config.WIDTH_RIGHT, newValue -> {
+        widthRightField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 0,100, "Width Right", Config.WIDTH_RIGHT, newValue -> {
             Config.WIDTH_RIGHT.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "widthRight");
         });
@@ -165,7 +165,7 @@ public class ConfigScreen extends Screen {
         yStart += stepSize;
 
         // Layer Offset Slider
-        layerOffsetField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, 100, "Layer Offset", Config.LAYER_OFFSET, newValue -> {
+        layerOffsetField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, -64,256, "Layer Offset", Config.LAYER_OFFSET, newValue -> {
             Config.LAYER_OFFSET.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "layerOffset");
         });

--- a/src/main/java/com/ael/viner/gui/ConfigScreen.java
+++ b/src/main/java/com/ael/viner/gui/ConfigScreen.java
@@ -111,7 +111,7 @@ public class ConfigScreen extends Screen {
 
         yStart += stepSize;
 
-        exhaustionPerBlockField = GuiUtils.createConfigSlider(leftColumnX, yStart, boxWidth, 20,20, "Hunger Per Block", Config.EXHAUSTION_PER_BLOCK, newValue -> {
+        exhaustionPerBlockField = GuiUtils.createConfigSlider(leftColumnX, yStart, boxWidth, 20, 20, "Hunger Per Block", Config.EXHAUSTION_PER_BLOCK, newValue -> {
             Config.EXHAUSTION_PER_BLOCK.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.DOUBLE, newValue, "exhaustionPerBlock");
         });
@@ -165,7 +165,7 @@ public class ConfigScreen extends Screen {
         yStart += stepSize;
 
         // Layer Offset Slider
-        layerOffsetField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, -64,256, "Layer Offset", Config.LAYER_OFFSET, newValue -> {
+        layerOffsetField = GuiUtils.createConfigSlider(rightColumnX, yStart, boxWidth, 20, -64, 256, "Layer Offset", Config.LAYER_OFFSET, newValue -> {
             Config.LAYER_OFFSET.set(newValue);
             syncConfigWithServer(ConfigSyncPacket.ConfigType.INT, newValue, "layerOffset");
         });

--- a/src/main/java/com/ael/viner/gui/GuiUtils.java
+++ b/src/main/java/com/ael/viner/gui/GuiUtils.java
@@ -57,21 +57,21 @@ public class GuiUtils {
         };
     }
 
-    public static AbstractSliderButton createConfigSlider(int x, int y, int width, int height, int upperLimit, String label, Supplier<Integer> getter, Consumer<Integer> setter) {
+    public static AbstractSliderButton createConfigSlider(int x, int y, int width, int height, int lowerLimit, int upperLimit, String label, Supplier<Integer> getter, Consumer<Integer> setter) {
         return new AbstractSliderButton(x, y, width, height, Component.empty(), getter.get() / (double) upperLimit) {
             {
-                this.value = getter.get() / (double) upperLimit; // Normalize value (assuming 0-100 range for slider)
+                this.value = (getter.get() - lowerLimit) / (double) (upperLimit - lowerLimit); // Normalize value
                 updateMessage();
             }
 
             @Override
             protected void updateMessage() {
-                setMessage(Component.literal(label + ": " + (int) (this.value * upperLimit)));
+                setMessage(Component.literal(label + ": " + (int) (this.value * (upperLimit - lowerLimit) + lowerLimit)));
             }
 
             @Override
             protected void applyValue() {
-                setter.accept((int) (this.value * upperLimit)); // Apply value, denormalize it back
+                setter.accept((int) (this.value * (upperLimit - lowerLimit) + lowerLimit)); // Apply value, denormalize it back
             }
         };
     }


### PR DESCRIPTION
I updated the normalization code to now take in a lower limit. Initially, this assumed that the lower limit would always be 0. With a recent change, the lower limit for some configurations would now accept negative values, while the GUI only showed positive values. 

This change updated the normalization to account for negative values as well.